### PR TITLE
Update log filename prefix

### DIFF
--- a/Bot/bot_QA_Logger.py
+++ b/Bot/bot_QA_Logger.py
@@ -6,7 +6,7 @@ from Bot.log_to_telegram import TelegramLogHandler
 
 # Генерируем уникальное имя файла логов с увеличением цифр
 def get_log_filename():
-    base_name = datetime.now().strftime('bat_log_%Y-%m-%d')
+    base_name = datetime.now().strftime('bot_log_%Y-%m-%d')
     counter = 1
     log_filename = os.path.join(config.log_dir, f"{base_name}_{counter}.log")
 


### PR DESCRIPTION
## Summary
- fix typo in log filename prefix

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'Bot')*

------
https://chatgpt.com/codex/tasks/task_e_684202601e3c8329a15d74886e5b8ee6